### PR TITLE
Fix timestamp for file input

### DIFF
--- a/sapito.py
+++ b/sapito.py
@@ -53,6 +53,9 @@ def do(pkt):
             add_client(shw, srcip)
             UDPlayer = pkt[UDP]
             #len = UDPlayer.len
+
+            timestamp = float(pkt.time)
+            human_readable_time = datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')
             if DNS in UDPlayer:
                 DNSlayer = pkt[UDP][DNS]
                 # The DNSlayer.fields are:
@@ -64,7 +67,7 @@ def do(pkt):
                 num_answers = DNSlayer.ancount
                 # TODO: Find the Authoritative Nameservers
 
-                print(bcolors.HEADER + f"\033[36m{datetime.now()}\033[95m | SrcMAC: \033[36m{shw}\033[95m | Vendor: \033[36m{mac_vendor}\033[95m | SrcIP: \033[36m{srcip}\033[95m | Name: \033[36m{get_client(shw)['name']}\033[95m | Questions: \033[36m{num_questions}\033[95m | Additional Records: \033[36m{num_additional_records}\033[95m | Answers: \033[36m{num_answers}\033[95m" + bcolors.ENDC)
+                print(bcolors.HEADER + f"\033[36m{human_readable_time}\033[95m | SrcMAC: \033[36m{shw}\033[95m | Vendor: \033[36m{mac_vendor}\033[95m | SrcIP: \033[36m{srcip}\033[95m | Name: \033[36m{get_client(shw)['name']}\033[95m | Questions: \033[36m{num_questions}\033[95m | Additional Records: \033[36m{num_additional_records}\033[95m | Answers: \033[36m{num_answers}\033[95m" + bcolors.ENDC)
                 try:
                     question_name = DNSlayer.fields['qd']
                 except KeyError:


### PR DESCRIPTION
# Description
Read the timestamp from the packet. This works for both the pcap file parsing and the real time sniffing from the interface.

Fixes #2 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Run `python sapito.py -i wlo1` and verified the timestamp is printed correctly.
- [X] Run `python -r file.pcap` and verified the timestamp is printed correctly.


# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

# Changes to the documentation
N/A
